### PR TITLE
save operational params in the same way with delta io

### DIFF
--- a/rust/src/action/mod.rs
+++ b/rust/src/action/mod.rs
@@ -509,9 +509,14 @@ impl DeltaOperation {
         );
 
         if let Ok(serde_json::Value::Object(map)) = serde_json::to_value(self) {
+            let all_operation_fields = map.values().next().unwrap().as_object().unwrap();
+            let converted_operation_fields: Map<String, Value> = all_operation_fields.iter()
+                .filter(|item| !item.1.is_null())
+                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.to_string()))).collect();
+
             commit_info.insert(
                 "operationParameters".to_string(),
-                map.values().next().unwrap().clone(),
+                serde_json::Value::Object(converted_operation_fields),
             );
         };
 

--- a/rust/tests/command_optimize.rs
+++ b/rust/tests/command_optimize.rs
@@ -493,7 +493,7 @@ async fn test_commit_info() -> Result<(), Box<dyn Error>> {
     assert_eq!(last_commit["readVersion"], json!(version));
     assert_eq!(
         last_commit["operationParameters"]["targetSize"],
-        json!(2_000_000)
+        json!("2000000")
     );
     // TODO: Requires a string representation for PartitionFilter
     assert_eq!(last_commit["operationParameters"]["predicate"], Value::Null);


### PR DESCRIPTION
# Description
Currently writing "operationParameters" in commit info is misaligned with delta io connector. 

[Here](https://github.com/delta-io/delta/blob/36a7edb8cf507e713700ba827c5fb5ad32b9163e/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala#L695) the sample of structure which is used in delta io. 

So the goal of this PR is to align with delta io approach and the PR do two thins: convert all values to string and delete keys with null values. 

# Related Issue(s)
Closes [issue #1017](https://github.com/delta-io/delta-rs/issues/1017)